### PR TITLE
Fix dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.3-alpine
 
-RUN gem install yaml_vault aws-sdk --no-document
+RUN gem install yaml_vault --no-document
 
 ENTRYPOINT ["yaml_vault"]

--- a/yaml_vault.gemspec
+++ b/yaml_vault.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", ">= 4"
+  spec.add_runtime_dependency "aws-sdk", "~> 2.0"
   spec.add_runtime_dependency "thor"
 
-  spec.add_development_dependency "aws-sdk", "~> 2.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
`aws-sdk` isn't a development dependency. Also you know It's required in `lib/yaml_vault.rb`.

Thanks. :sparkles:
