### PR TITLE
Fix matching symbol keys

### DIFF
--- a/lib/yaml_vault/key_parser.rb
+++ b/lib/yaml_vault/key_parser.rb
@@ -20,6 +20,8 @@ module YamlVault
           path << Regexp.new(s[1])
         elsif token = s.scan(/\[(\d+)\]/)
           path << s[1].to_i
+        elsif token = s.scan(/:([^\.]+)/)
+          path << s[1].to_sym
         elsif token = s.scan(/\./)
           # noop
         elsif token = s.scan(/[^\.]*/)

--- a/lib/yaml_vault/yaml_tree_builder.rb
+++ b/lib/yaml_vault/yaml_tree_builder.rb
@@ -106,6 +106,8 @@ module YamlVault
           else
             if path.is_a?(Regexp)
               path.match(@path_stack[i])
+            elsif path.is_a?(Symbol)
+              path.inspect == @path_stack[i]
             else
               path == @path_stack[i]
             end

--- a/spec/sample.yml
+++ b/spec/sample.yml
@@ -33,3 +33,6 @@ vault:
     - :a:
         b: !ruby/range 1..10
     - [{key1: val1, key2: val2}, {key3: val3}]
+
+:symbolized_vault_key:
+  secret_data: "hogehoge"

--- a/spec/yaml_vault/key_parser_spec.rb
+++ b/spec/yaml_vault/key_parser_spec.rb
@@ -9,7 +9,7 @@ describe YamlVault::KeyParser do
     context %q{str = $.foo.bar.*.[0].:sym.'hoge.fuga'."quoted.path"./regexp/} do
       let(:str) { %q{$.foo.bar.*.[0].:sym.'hoge.fuga'."quoted.path"./regexp/} }
 
-      it { is_expected.to eq(["$", "foo", "bar", "*", 0, ":sym", "hoge.fuga", "quoted.path", /regexp/]) }
+      it { is_expected.to eq(["$", "foo", "bar", "*", 0, :sym, "hoge.fuga", "quoted.path", /regexp/]) }
     end
 
     context %q{str = $.'[0]'.':hoge."fuga"'."'path"./\Areg\.exp/} do

--- a/spec/yaml_vault_spec.rb
+++ b/spec/yaml_vault_spec.rb
@@ -52,6 +52,14 @@ describe YamlVault do
         end
       end
     end
+
+    context "include symbolized matching key" do
+      let(:key) { ["$", :symbolized_vault_key] }
+      it 'generate encrypt yaml' do
+        encrypted = YAML.load(YamlVault::Main.from_file(File.expand_path("../sample.yml", __FILE__), [key], passphrase: "testpassphrase").encrypt_yaml)
+        expect(encrypted[:symbolized_vault_key]["secret_data"]).not_to eq "hogehoge"
+      end
+    end
   end
 
   describe ".decrypt_hash" do


### PR DESCRIPTION
In case of using symbolized keys on ruby script, encypted keys unprocessed.