### PR TITLE
Added suffix and prefix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 
 .envrc
+.idea

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ vault:
 
 ex. `$.production.:slaves.[0].*.:password`
 
-You can also use the `--prefix` and `--suffix` options to format the encrypted value. i.e by providing `--prefix "ENC(" --sufix ")"` you can get the following output from the above example:
+You can also use the `--prefix` and `--suffix` options to format the encrypted value. i.e by providing `--prefix "ENC(" --suffix ")"` you can get the following output from the above example:
 
 ```yml
 # encrypted_secrets.yml

--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ vault:
 
 ex. `$.production.:slaves.[0].*.:password`
 
+You can also use the `--prefix` and `--suffix` options to format the encrypted value. i.e by providing `--prefix "ENC(" --sufix ")"` you can get the following output from the above example:
+
+```yml
+# encrypted_secrets.yml
+
+default: &default
+...
+vault:
+  secret_data: ENC(SzZoOGlpcSs4UlBaQnhTYWx0YlN3NHk2QXhiZGYvVmpsc0c3ckllSlh1TT0tLU13ZERzRWsxaGc0Y090blNIdXVVMmc9PQ==--24b2af56d2563776ca316dbfa243333dd053fea1)
+...
+```
+
 #### AWS KMS Encryption
 
 Max encryptable size is 4096 bytes. (value size as encoded by Base64)
@@ -214,6 +226,8 @@ Enter passphrase: <enter your passphrase>
 ```
 
 If `ENV["YAML_VAULT_PASSPHRASE"]`, use it as passphrase
+
+Note to pass the same `--suffix` and `--prefix` if the yaml was encrypted using these options.
 
 #### AWS KMS Decryption
 

--- a/exe/yaml_vault
+++ b/exe/yaml_vault
@@ -8,6 +8,8 @@ class YamlVault::Cli < Thor
   include Thor::Actions
 
   class_option :key, aliases: "-k", type: :string, banner: "KEYNAME (format: \"KEY1.INNER_KEY,KEY2\")", desc: "target key", default: "$"
+  class_option :prefix, type: :string, banner: "PREFIX", desc: "prefix string to add to the encrypted value"
+  class_option :suffix, type: :string, banner: "SUFFIX", desc: "suffix string to add to the encrypted value"
   class_option :cryptor, type: :string, enum: %w(simple aws-kms gcp-kms), default: "simple"
 
   class_option :salt, aliases: "-s", type: :string
@@ -33,6 +35,8 @@ class YamlVault::Cli < Thor
     encrypted_yaml = YamlVault::Main.from_file(
       yaml_file,
       target_keys,
+      options[:prefix],
+      options[:suffix],
       options[:cryptor],
       passphrase: passphrase,
       sign_passphrase: sign_passphrase,
@@ -57,6 +61,8 @@ class YamlVault::Cli < Thor
     decrypted_yaml = YamlVault::Main.from_file(
       yaml_file,
       target_keys,
+      options[:prefix],
+      options[:suffix],
       options[:cryptor],
       passphrase: passphrase,
       sign_passphrase: sign_passphrase,

--- a/lib/yaml_vault.rb
+++ b/lib/yaml_vault.rb
@@ -11,22 +11,24 @@ require 'yaml_vault/yaml_tree_builder'
 module YamlVault
   class Main
     class << self
-      def from_file(filename, keys, cryptor_name = nil, **options)
+      def from_file(filename, keys, prefix = nil, suffix = nil, cryptor_name = nil, **options)
         yaml_content = ERB.new(File.read(filename)).result
-        new(yaml_content, keys, cryptor_name, **options)
+        new(yaml_content, keys, prefix, suffix, cryptor_name, **options)
       end
 
       alias :from_content :new
     end
 
     def initialize(
-      yaml_content, keys, cryptor_name = nil,
+      yaml_content, keys, prefix = nil, suffix = nil, cryptor_name = nil,
       passphrase: nil, sign_passphrase: nil, salt: nil, cipher: "aes-256-cbc", key_len: 32, signature_key_len: 64, digest: "SHA256",
       aws_kms_key_id: nil, aws_region: nil, aws_access_key_id: nil, aws_secret_access_key: nil, aws_profile: nil,
       gcp_kms_resource_id: nil, gcp_credential_file: nil
     )
       @yaml = yaml_content
       @keys = keys
+      @prefix = prefix
+      @suffix = suffix
 
       @passphrase = passphrase
       @sign_passphrase = sign_passphrase
@@ -49,12 +51,12 @@ module YamlVault
     end
 
     def encrypt
-      parser = YAML::Parser.new(YamlVault::YAMLTreeBuilder.new(@keys, @cryptor, :encrypt))
+      parser = YAML::Parser.new(YamlVault::YAMLTreeBuilder.new(@keys, @prefix, @suffix, @cryptor, :encrypt))
       parser.parse(@yaml).handler.root
     end
 
     def decrypt
-      parser = YAML::Parser.new(YamlVault::YAMLTreeBuilder.new(@keys, @cryptor, :decrypt))
+      parser = YAML::Parser.new(YamlVault::YAMLTreeBuilder.new(@keys, @prefix, @suffix, @cryptor, :decrypt))
       parser.parse(@yaml).handler.root
     end
 

--- a/lib/yaml_vault/version.rb
+++ b/lib/yaml_vault/version.rb
@@ -1,3 +1,3 @@
 module YamlVault
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/lib/yaml_vault/yaml_tree_builder.rb
+++ b/lib/yaml_vault/yaml_tree_builder.rb
@@ -8,8 +8,8 @@ module YamlVault
 
       @path_stack = []
       @target_paths = target_paths
-      @prefix = prefix.to_s
-      @suffix = suffix.to_s
+      @prefix = prefix
+      @suffix = suffix
       @cryptor = cryptor
       @mode = mode
     end
@@ -105,13 +105,7 @@ module YamlVault
     private
 
     def handle_prefix(value)
-      if @prefix != nil
-        value = "#{@prefix}#{value}"
-      end
-      if @suffix != nil
-        value = "#{value}#{@suffix}"
-      end
-      return value
+      return "#{@prefix}#{value}#{@suffix}"
     end
 
     def handle_suffix(value)

--- a/lib/yaml_vault/yaml_tree_builder.rb
+++ b/lib/yaml_vault/yaml_tree_builder.rb
@@ -76,9 +76,9 @@ module YamlVault
           else
             result.value = @cryptor.encrypt(value)
           end
-          result.value = handle_prefix(result.value)
+          result.value = add_prefix_and_suffix(result.value)
         else
-          value = handle_suffix(value)
+          value = remove_prefix_and_suffix(value)
           decrypted_value = @cryptor.decrypt(value).to_s
           if decrypted_value =~ /\A(!.*?)\s+(.*)\z/
             result.tag = $1
@@ -104,11 +104,11 @@ module YamlVault
 
     private
 
-    def handle_prefix(value)
+    def add_prefix_and_suffix(value)
       return "#{@prefix}#{value}#{@suffix}"
     end
 
-    def handle_suffix(value)
+    def remove_prefix_and_suffix(value)
       if @prefix != nil && value.start_with?(@prefix)
         value = value.delete_prefix(@prefix)
       end

--- a/spec/yaml_vault_spec.rb
+++ b/spec/yaml_vault_spec.rb
@@ -13,7 +13,7 @@ describe YamlVault, aggregate_failures: true do
           expect(origin["vault"]["secrets"][1]).to eq 1
           expect(origin["vault"]["secrets"][2]).to eq "two"
           expect(origin["vault"]["secrets"][3]).to eq true
-          expect(origin["vault"]["secrets"][4]).to eq({"four" => 4})
+          expect(origin["vault"]["secrets"][4]).to eq({ "four" => 4 })
           expect(origin["vault"]["secrets"][5]).to eq(:five)
           expect(origin["vault"]["secrets"][6]).to eq("bar")
           expect(origin["vault"]["secrets"][7][:a]["b"]).to eq(1..10)
@@ -26,7 +26,7 @@ describe YamlVault, aggregate_failures: true do
           expect(encrypted["vault"]["secrets"][1]).not_to eq 1
           expect(encrypted["vault"]["secrets"][2]).not_to eq "two"
           expect(encrypted["vault"]["secrets"][3]).not_to eq true
-          expect(encrypted["vault"]["secrets"][4]).not_to eq({"four" => 4})
+          expect(encrypted["vault"]["secrets"][4]).not_to eq({ "four" => 4 })
           expect(encrypted["vault"]["secrets"][5]).not_to eq(:five)
           expect(encrypted["vault"]["secrets"][6]).to eq("bar")
           expect(encrypted["vault"]["secrets"][7][:a]["b"]).not_to eq(1..10)
@@ -46,7 +46,7 @@ describe YamlVault, aggregate_failures: true do
           expect(encrypted["vault"]["secrets"][1]).not_to eq 1
           expect(encrypted["vault"]["secrets"][2]).not_to eq "two"
           expect(encrypted["vault"]["secrets"][3]).not_to eq true
-          expect(encrypted["vault"]["secrets"][4]).not_to eq({"four" => 4})
+          expect(encrypted["vault"]["secrets"][4]).not_to eq({ "four" => 4 })
           expect(encrypted["vault"]["secrets"][5]).not_to eq(:five)
           expect(encrypted["vault"]["secrets"][6]).to eq("bar")
           expect(encrypted["vault"]["secrets"][7][:a]["b"]).not_to eq(1..10)
@@ -63,6 +63,43 @@ describe YamlVault, aggregate_failures: true do
         expect(encrypted[:symbolized_vault_key]["secret_data"]).not_to eq "hogehoge"
       end
     end
+
+    context "use prefix and suffix" do
+      it 'generate encrypt yaml' do
+        yaml_file = File.expand_path("../sample.yml", __FILE__)
+        origin = YAML.load_file(yaml_file)
+        encrypted = YAML.load(YamlVault::Main.from_file(yaml_file, [["$", "vault"], ["$", "default", /\Aa/]], "{ENC:", "}", passphrase: "testpassphrase", sign_passphrase: "signpassphrase").encrypt_yaml)
+        aggregate_failures do
+          expect(origin["vault"]["secret_data"]).to eq "hogehoge"
+          expect(origin["vault"]["secrets"][0]).to eq 0
+          expect(origin["vault"]["secrets"][1]).to eq 1
+          expect(origin["vault"]["secrets"][2]).to eq "two"
+          expect(origin["vault"]["secrets"][3]).to eq true
+          expect(origin["vault"]["secrets"][4]).to eq({ "four" => 4 })
+          expect(origin["vault"]["secrets"][5]).to eq(:five)
+          expect(origin["vault"]["secrets"][6]).to eq("bar")
+          expect(origin["vault"]["secrets"][7][:a]["b"]).to eq(1..10)
+          expect(origin["vault"]["secrets"][8][0]["key1"]).to eq("val1")
+          expect(origin["foo"]).to eq "bar"
+          expect(origin["default"]["aaa"]).to eq true
+
+          expect(encrypted["vault"]["secret_data"]).not_to eq "hogehoge"
+          expect(encrypted["vault"]["secret_data"]).to start_with "{ENC:"
+          expect(encrypted["vault"]["secret_data"]).to end_with "}"
+          expect(encrypted["vault"]["secrets"][0]).not_to eq 0
+          expect(encrypted["vault"]["secrets"][1]).not_to eq 1
+          expect(encrypted["vault"]["secrets"][2]).not_to eq "two"
+          expect(encrypted["vault"]["secrets"][3]).not_to eq true
+          expect(encrypted["vault"]["secrets"][4]).not_to eq({ "four" => 4 })
+          expect(encrypted["vault"]["secrets"][5]).not_to eq(:five)
+          expect(encrypted["vault"]["secrets"][6]).to eq("bar")
+          expect(encrypted["vault"]["secrets"][7][:a]["b"]).not_to eq(1..10)
+          expect(encrypted["vault"]["secrets"][8][0]["key1"]).not_to eq("val1")
+          expect(encrypted["foo"]).to eq "bar"
+          expect(encrypted["default"]["aaa"]).not_to eq true
+        end
+      end
+    end
   end
 
   describe ".decrypt_hash" do
@@ -74,7 +111,7 @@ describe YamlVault, aggregate_failures: true do
         expect(decrypted["vault"]["secrets"][1]).to eq 1
         expect(decrypted["vault"]["secrets"][2]).to eq "two"
         expect(decrypted["vault"]["secrets"][3]).to eq true
-        expect(decrypted["vault"]["secrets"][4]).to eq({"four" => 4})
+        expect(decrypted["vault"]["secrets"][4]).to eq({ "four" => 4 })
         expect(decrypted["vault"]["secrets"][5]).to eq(:five)
         expect(decrypted["vault"]["secrets"][6][:a]["b"]).to eq(1..10)
         expect(decrypted["vault"]["secrets"][7][0]["key1"]).to eq("val1")
@@ -92,7 +129,7 @@ describe YamlVault, aggregate_failures: true do
         expect(decrypted["vault"]["secrets"][1]).to eq 1
         expect(decrypted["vault"]["secrets"][2]).to eq "two"
         expect(decrypted["vault"]["secrets"][3]).to eq true
-        expect(decrypted["vault"]["secrets"][4]).to eq({"four" => 4})
+        expect(decrypted["vault"]["secrets"][4]).to eq({ "four" => 4 })
         expect(decrypted["vault"]["secrets"][5]).to eq(:five)
         expect(decrypted["vault"]["secrets"][6][:a]["b"]).to eq(1..10)
         expect(decrypted["vault"]["secrets"][7][0]["key1"]).to eq("val1")
@@ -135,7 +172,7 @@ describe YamlVault, aggregate_failures: true do
           expect(encrypted["vault"]["secrets"][1]).not_to eq 1
           expect(encrypted["vault"]["secrets"][2]).not_to eq "two"
           expect(encrypted["vault"]["secrets"][3]).not_to eq true
-          expect(encrypted["vault"]["secrets"][4]).not_to eq({"four" => 4})
+          expect(encrypted["vault"]["secrets"][4]).not_to eq({ "four" => 4 })
           expect(encrypted["vault"]["secrets"][5]).not_to eq(:five)
           expect(encrypted["vault"]["secrets"][6][:a]["b"]).not_to eq(1..10)
           expect(encrypted["vault"]["secrets"][7][0]["key1"]).not_to eq("val1")
@@ -149,7 +186,7 @@ describe YamlVault, aggregate_failures: true do
           expect(decrypted["vault"]["secrets"][1]).to eq 1
           expect(decrypted["vault"]["secrets"][2]).to eq "two"
           expect(decrypted["vault"]["secrets"][3]).to eq true
-          expect(decrypted["vault"]["secrets"][4]).to eq({"four" => 4})
+          expect(decrypted["vault"]["secrets"][4]).to eq({ "four" => 4 })
           expect(decrypted["vault"]["secrets"][5]).to eq(:five)
           expect(decrypted["vault"]["secrets"][6][:a]["b"]).to eq(1..10)
           expect(decrypted["vault"]["secrets"][7][0]["key1"]).to eq("val1")
@@ -169,7 +206,7 @@ describe YamlVault, aggregate_failures: true do
           expect(encrypted["vault"]["secrets"][1]).not_to eq 1
           expect(encrypted["vault"]["secrets"][2]).not_to eq "two"
           expect(encrypted["vault"]["secrets"][3]).not_to eq true
-          expect(encrypted["vault"]["secrets"][4]).not_to eq({"four" => 4})
+          expect(encrypted["vault"]["secrets"][4]).not_to eq({ "four" => 4 })
           expect(encrypted["vault"]["secrets"][5]).not_to eq(:five)
           expect(encrypted["vault"]["secrets"][6][:a]["b"]).not_to eq(1..10)
           expect(encrypted["vault"]["secrets"][7][0]["key1"]).not_to eq("val1")
@@ -183,7 +220,7 @@ describe YamlVault, aggregate_failures: true do
           expect(decrypted["vault"]["secrets"][1]).to eq 1
           expect(decrypted["vault"]["secrets"][2]).to eq "two"
           expect(decrypted["vault"]["secrets"][3]).to eq true
-          expect(decrypted["vault"]["secrets"][4]).to eq({"four" => 4})
+          expect(decrypted["vault"]["secrets"][4]).to eq({ "four" => 4 })
           expect(decrypted["vault"]["secrets"][5]).to eq(:five)
           expect(decrypted["vault"]["secrets"][6][:a]["b"]).to eq(1..10)
           expect(decrypted["vault"]["secrets"][7][0]["key1"]).to eq("val1")
@@ -201,7 +238,7 @@ describe YamlVault, aggregate_failures: true do
           expect(encrypted["vault"]["secrets"][1]).not_to eq 1
           expect(encrypted["vault"]["secrets"][2]).not_to eq "two"
           expect(encrypted["vault"]["secrets"][3]).not_to eq true
-          expect(encrypted["vault"]["secrets"][4]).not_to eq({"four" => 4})
+          expect(encrypted["vault"]["secrets"][4]).not_to eq({ "four" => 4 })
           expect(encrypted["vault"]["secrets"][5]).not_to eq(:five)
           expect(encrypted["vault"]["secrets"][6][:a]["b"]).not_to eq(1..10)
           expect(encrypted["vault"]["secrets"][7][0]["key1"]).not_to eq("val1")
@@ -215,7 +252,7 @@ describe YamlVault, aggregate_failures: true do
           expect(decrypted["vault"]["secrets"][1]).to eq 1
           expect(decrypted["vault"]["secrets"][2]).to eq "two"
           expect(decrypted["vault"]["secrets"][3]).to eq true
-          expect(decrypted["vault"]["secrets"][4]).to eq({"four" => 4})
+          expect(decrypted["vault"]["secrets"][4]).to eq({ "four" => 4 })
           expect(decrypted["vault"]["secrets"][5]).to eq(:five)
           expect(decrypted["vault"]["secrets"][6][:a]["b"]).to eq(1..10)
           expect(decrypted["vault"]["secrets"][7][0]["key1"]).to eq("val1")


### PR DESCRIPTION
Motivation:
I want to know if a specific value in a given yaml file is already encrypted or no.
If I encrypt values such as base64 tokens or passwords (that are indeed secrets), I get an output that "looks the same".
The suffix and prefix allow the user to decorate the encrypted value with some indication of being encrypted.
Specifically, our organization uses a product to detect exposed secrets in the code base. It'd know to ignore values that are decorated with for example `ENC(...)`, but some random looking base64 string is more suspicious.

sorry I'm not really a Ruby programmer, so feel free to fix any syntax or code styling

