### PR TITLE
Change the order of the arguments from_file and initialize

### DIFF
--- a/lib/yaml_vault.rb
+++ b/lib/yaml_vault.rb
@@ -11,16 +11,16 @@ require 'yaml_vault/yaml_tree_builder'
 module YamlVault
   class Main
     class << self
-      def from_file(filename, keys, prefix = nil, suffix = nil, cryptor_name = nil, **options)
+      def from_file(filename, keys, cryptor_name = nil, prefix = nil, suffix = nil, **options)
         yaml_content = ERB.new(File.read(filename)).result
-        new(yaml_content, keys, prefix, suffix, cryptor_name, **options)
+        new(yaml_content, keys, cryptor_name, prefix, suffix, **options)
       end
 
       alias :from_content :new
     end
 
     def initialize(
-      yaml_content, keys, prefix = nil, suffix = nil, cryptor_name = nil,
+      yaml_content, keys, cryptor_name = nil, prefix = nil, suffix = nil,
       passphrase: nil, sign_passphrase: nil, salt: nil, cipher: "aes-256-cbc", key_len: 32, signature_key_len: 64, digest: "SHA256",
       aws_kms_key_id: nil, aws_region: nil, aws_access_key_id: nil, aws_secret_access_key: nil, aws_profile: nil,
       gcp_kms_resource_id: nil, gcp_credential_file: nil

--- a/spec/yaml_vault_spec.rb
+++ b/spec/yaml_vault_spec.rb
@@ -68,7 +68,7 @@ describe YamlVault, aggregate_failures: true do
       it 'generate encrypt yaml' do
         yaml_file = File.expand_path("../sample.yml", __FILE__)
         origin = YAML.load_file(yaml_file)
-        encrypted = YAML.load(YamlVault::Main.from_file(yaml_file, [["$", "vault"], ["$", "default", /\Aa/]], "{ENC:", "}", passphrase: "testpassphrase", sign_passphrase: "signpassphrase").encrypt_yaml)
+        encrypted = YAML.load(YamlVault::Main.from_file(yaml_file, [["$", "vault"], ["$", "default", /\Aa/]], nil, "{ENC:", "}", passphrase: "testpassphrase", sign_passphrase: "signpassphrase").encrypt_yaml)
         aggregate_failures do
           expect(origin["vault"]["secret_data"]).to eq "hogehoge"
           expect(origin["vault"]["secrets"][0]).to eq 0


### PR DESCRIPTION
We have a workflow for AWS KMS that uses [Direct Assignment](https://github.com/joker1007/yaml_vault#direct-assignment), and it is not working with https://github.com/joker1007/yaml_vault/pull/18.
This is because the third argument is now treated as a prefix.

It can be fixed by making the argument order like this PR, which feels right to me. How do you think about that? 