### PR TITLE
Support both Psych 3 and 4

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@v1.75.0
+      uses: ruby/setup-ruby@v1.110.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/lib/yaml_vault.rb
+++ b/lib/yaml_vault.rb
@@ -7,8 +7,10 @@ require 'pp'
 
 require 'yaml_vault/key_parser'
 require 'yaml_vault/yaml_tree_builder'
+require 'yaml_vault/yaml_compat'
 
 module YamlVault
+  using YamlVault::YAMLCompat
   class Main
     class << self
       def from_file(filename, keys, cryptor_name = nil, prefix = nil, suffix = nil, **options)

--- a/lib/yaml_vault/yaml_compat.rb
+++ b/lib/yaml_vault/yaml_compat.rb
@@ -1,0 +1,21 @@
+module YamlVault
+  module YAMLCompat
+    refine YAML.singleton_class do
+      def load(yaml, **kw)
+        if YAML.respond_to?(:unsafe_load)
+          YAML.unsafe_load(yaml, **kw)
+        else
+          super(yaml, **kw)
+        end
+      end
+
+      def load_file(filename, **kw)
+        if YAML.respond_to?(:unsafe_load_file)
+          YAML.unsafe_load_file(filename, **kw)
+        else
+          super(filename, **kw)
+        end
+      end
+    end
+  end
+end

--- a/spec/yaml_vault_spec.rb
+++ b/spec/yaml_vault_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe YamlVault, aggregate_failures: true do
+  using YamlVault::YAMLCompat
   describe ".encrypt_yaml" do
     context "use sign_passphrase" do
       it 'generate encrypt yaml' do


### PR DESCRIPTION
Ruby 3.1.2 includes Psych 4.0.4 by default.
So I met some breaking changes I use this gem with Ruby 3.1.2.

I've added the compat layer for this.

See also:
- https://bugs.ruby-lang.org/issues/17866
- https://github.com/rails/rails/pull/42257/files