### PR TITLE
Fix stray quotation mark in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ vault:
 ```
 
 ```
-% yaml_vault encrypt secrets.yml -o encrypted_secrets.yml"
+% yaml_vault encrypt secrets.yml -o encrypted_secrets.yml
 Enter passphrase: <enter your passphrase>
 ```
 


### PR DESCRIPTION
Fixed a typo in the `README` by removing an unnecessary quotation mark from the `yaml_vault encrypt` command example.